### PR TITLE
Adds a script to setup an editor role in an RS instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Heading
+
+## Setup editor role
+
+To setup a user role that is allowed to add and edit data in an instance of the
+ResearchSpace platform that hasn't defined such yet, run this script from the
+instance's project folder on the host:
+
+    apps/entermuseum4punkt0/setup-role.sh
+
+This refers to instances setup with https://github.com/funkyfuture/m4p0-researchspace-deployment

--- a/setup-role.sh
+++ b/setup-role.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ROLE="TODO"
+
+test -f docker-compose.yml && test -f Dockerfile && echo "The current working directory seems not to be a suited poject folder." && exit 1
+
+docker-compose exec -u jetty platform /bin/sh -c "echo -e '\n$ROLE' >> /runtime-data/config/shiro.ini"
+docker-compose restart platform

--- a/setup-role.sh
+++ b/setup-role.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ROLE="TODO"
+ROLE="editor=forms:ldp:*"
 
 test -f docker-compose.yml && test -f Dockerfile && echo "The current working directory seems not to be a suited poject folder." && exit 1
 


### PR DESCRIPTION
please not that you have to amend the `ROLE`'s value.

my only concern atm is that the platform nags about the unexpected script file in the app folder (later after the image had been rebuild), but iirc it only nags and works anyway.